### PR TITLE
update docs, remove main.md, update pre-commit prettier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,10 +19,3 @@ repos:
         args: [--fix]
       # Run the formatter.
       - id: ruff-format
-
-  # yaml formatting
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
-    hooks:
-      - id: prettier
-        types: [yaml]

--- a/docs/main.md
+++ b/docs/main.md
@@ -1,1 +1,0 @@
-:::encoders.main

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,7 +8,6 @@ nav:
       - Intro: https://kristijanarmeni.github.io/encoders_report" target="_blank
   - "Documentation":
       - "run_all": "run_all.md"
-      - "main": "main.md"
       - "regression": "regression.md"
       - "features": "features.md"
       - "data": "data.md"


### PR DESCRIPTION
https://github.com/pre-commit/mirrors-prettier is archived seemingly due to breaking changes to prettier and the pre-commit hook is no longer maintained. Removing as the first-pass solution.