### PR TITLE
[FIX] data_dir, naming inconsistencies, and param naming

### DIFF
--- a/src/encoders/data.py
+++ b/src/encoders/data.py
@@ -19,7 +19,7 @@ cfg = load_config()
 DATADIR = Path(cfg["DATA_DIR"])
 STORIES = cfg["STORIES"]
 WAV_DIR = "stimuli"
-EMBEDDINGS_FILE = Path(DATADIR, "lebel_data", "english1000sm.hf5")
+EMBEDDINGS_FILE = Path("data", "lebel_data", "english1000sm.hf5")
 
 TEXT_GRID_FORMATS = [
     'File type = "ooTextFile"',

--- a/src/encoders/regression.py
+++ b/src/encoders/regression.py
@@ -450,19 +450,16 @@ def crossval_simple(
     """
 
     if stories is None:
-        stories = STORIES.copy()
+        stories = STORIES
         if not isinstance(stories, list):
             raise ValueError(f"Config parameter invalid: STORIES: {stories}")
+    stories = stories.copy()
 
     if n_train_stories is None:
         n_train_stories = len(stories) - 1
 
-    if test_story is not None:
-        try:
-            stories.remove(test_story)
-        except ValueError as e:
-            log.critical(f"test_story: {test_story} is not in the pool of all stories.")
-            raise e
+    if test_story is not None and test_story in stories:
+        stories.remove(test_story)
 
     rng = np.random.default_rng(seed=seed)
 

--- a/src/encoders/run_all.py
+++ b/src/encoders/run_all.py
@@ -175,7 +175,7 @@ def run_all(
         n_train_stories_list = n_train_stories
 
     # pick the right pool of stories, depending on ridge implementation
-    if ridge_implementation == "regression_huth":
+    if ridge_implementation == "ridge_huth":
         stories = load_config()["STORIES"].copy()
     elif ridge_implementation == "ridgeCV":
         stories = load_config()["STORIES_2"].copy()

--- a/src/encoders/utils.py
+++ b/src/encoders/utils.py
@@ -47,7 +47,11 @@ def load_config():
 
 
 def check_make_dirs(
-    paths: Union[str, List[str]],
+    paths: Union[
+        str,
+        Path,
+        List[Union[str, Path]],
+    ],
     verbose: bool = True,
     isdir: bool = False,
 ) -> None:

--- a/src/lebel_encoding/run_all_replication.py
+++ b/src/lebel_encoding/run_all_replication.py
@@ -27,7 +27,7 @@ STORIES = cfg["STORIES"]
 
 def run_all_replication(
     subject: str = "UTS02",
-    feature: Union[str, list[str]] = "eng1000",
+    feature: str = "eng1000",
     n_train_stories: Union[int, list[int]] = [1, 3, 5],
     test_story: str = "wheretheressmoke",
     n_repeats: int = 15,
@@ -62,12 +62,11 @@ def run_all_replication(
         Subject identifier.
         Can be one of: {`"all"`, `"UTS01"`, `"UTS02"`, `"UTS03"`, `"UTS04"`,
          `"UTS05"`, `"UTS06"`, `"UTS07"`, `"UTS08"`}
-    feature : {"all", "envelope", "eng1000"}, default="all"
-        Which predictor to run.
-        `all` will run separate encoding models for both predictors (default).
-        `envelope` will run the encoding model with the audio envelope as predictor.
+    feature : {"eng1000", "articulation", "phonemerate", "wordrate"}, default="all"
+        Which feature to run.
         `eng1000` will run the encoding model with the word embeddings of the stories
          as predictor.
+        The other features have not been tested in this codebase (but may work).
     n_train_stories : int or list of int
         Number o of training stories for the encoding model. If a list is given, the
          encoding model will be fitted with each number separately.
@@ -141,7 +140,7 @@ def run_all_replication(
         output_dir = os.path.join(
             run_folder,
             subject,
-            "embeddings",  # only option here
+            feature,
             str(current_n_train_stories),
             "not_shuffled",
         )


### PR DESCRIPTION
* Reverted path towards embeddings file to `data` this is by design, and should not be defined in the config
* Fixed a bug where `stories` was modified (instead of a copy) in `regression.py` leading that after the first n_train_stories a value error came up. Stories now are copied, and the valueerror is also removed, as it would lead to natural error immediately after anyways.
* Features in `run_all_replication.py` were saved into `embeddings`, but now are saved into the feature name (e.g. `eng1000`), which makes it consistent with `run_all.py`
