### PR TITLE
[FIX] use absolute path to EMBEDDINGS_FILE

### DIFF
--- a/src/encoders/data.py
+++ b/src/encoders/data.py
@@ -11,7 +11,7 @@ import numpy as np
 import pandas as pd
 from scipy.io import wavfile
 
-from encoders.utils import get_logger, load_config
+from encoders.utils import ROOT_FOLDER, get_logger, load_config
 
 log = get_logger(__name__)
 cfg = load_config()
@@ -19,7 +19,7 @@ cfg = load_config()
 DATADIR = Path(cfg["DATA_DIR"])
 STORIES = cfg["STORIES"]
 WAV_DIR = "stimuli"
-EMBEDDINGS_FILE = Path("data", "lebel_data", "english1000sm.hf5")
+EMBEDDINGS_FILE = Path(ROOT_FOLDER, "data", "lebel_data", "english1000sm.hf5")
 
 TEXT_GRID_FORMATS = [
     'File type = "ooTextFile"',


### PR DESCRIPTION
Relates to #86. Note: for this to work properly, the code must be installed in editable mode (we must make sure to emphasize that in reproducibility instructions)