### PR TITLE
Test regression

### DIFF
--- a/src/encoders/regression.py
+++ b/src/encoders/regression.py
@@ -8,7 +8,7 @@ from typing import Callable, Optional, Union, cast
 import cortex
 import numpy as np
 from matplotlib import pyplot as plt
-from sklearn.linear_model import RidgeCV, Ridge
+from sklearn.linear_model import Ridge, RidgeCV
 from sklearn.model_selection import KFold
 
 from encoders.features import load_data_dict
@@ -193,6 +193,7 @@ def ridge_regression(
 
     return scores, clf.coef_, clf.alpha_
 
+
 def ridge_regression_chunkbootstrap(
     train_stories: list[str],
     test_stories: list[str],
@@ -202,11 +203,12 @@ def ridge_regression_chunkbootstrap(
     alphas: Optional[np.ndarray] = np.logspace(1, 3, 10),
     nboots: int = 50,
     chunklen: int = 40,
-    nchunks: int = 125
-)  -> tuple[np.ndarray, np.ndarray, Union[float, np.ndarray]]:
+    nchunks: int = 125,
+) -> tuple[np.ndarray, np.ndarray, Union[float, np.ndarray]]:
     """Runs Ridge regression with chunked bootstrapping on given train stories, returns
     scores for test story, regression weights, and the best alphas.
-    The function uses the Huth lab's chunked bootstrapping approach to find the best alphas with ridge regression implemented by sklearn.
+    The function uses the Huth lab's chunked bootstrapping approach to find
+    the best alphas with ridge regression implemented by sklearn.
 
     Parameters
     ----------
@@ -230,7 +232,8 @@ def ridge_regression_chunkbootstrap(
     chunklen : int, default = 40
         Length of chunks when splitting the data into chunks for bootstrapping.
     nchunks : int, default = 125
-        Number of chunks to be held out for alpha optimization; should not be more than 1/5 of the total number of chunks in training data.
+        Number of chunks to be held out for alpha optimization; should not be more
+        than 1/5 of the total number of chunks in training data.
 
     Returns
     -------
@@ -261,55 +264,71 @@ def ridge_regression_chunkbootstrap(
     X_train = z_score(X_train_unnormalized, X_means, X_stds)
     X_test = z_score(X_test_unnormalized, X_means, X_stds)
 
-    nchunks = min(nchunks, X_train.shape[0] // chunklen // 5)  # ensure that nchunks is not more than 1/5 of the total number of chunks
+    nchunks = min(
+        nchunks, X_train.shape[0] // chunklen // 5
+    )  # ensure that nchunks is not more than 1/5 of the total number of chunks
 
     n_total_chunks = X_train.shape[0] // chunklen
-    X_train_chunked = X_train[:n_total_chunks * chunklen].reshape(n_total_chunks, chunklen, -1)
-    y_train_chunked = y_train[:n_total_chunks * chunklen].reshape(n_total_chunks, chunklen, -1)
-    
+    X_train_chunked = X_train[: n_total_chunks * chunklen].reshape(
+        n_total_chunks, chunklen, -1
+    )
+    y_train_chunked = y_train[: n_total_chunks * chunklen].reshape(
+        n_total_chunks, chunklen, -1
+    )
+
     all_boot_scores = np.zeros((nboots, len(alphas), y_train.shape[1]))
-    
+
     for iboot in range(nboots):
         log.info(f"Bootstrap iteration {iboot + 1}/{nboots}")
-        
-        val_chunk_indices = np.random.choice(n_total_chunks, size=nchunks, replace=False)
+
+        val_chunk_indices = np.random.choice(
+            n_total_chunks, size=nchunks, replace=False
+        )
         train_chunk_indices = np.setdiff1d(np.arange(n_total_chunks), val_chunk_indices)
-        
-        X_train_boot = X_train_chunked[train_chunk_indices].reshape(-1, X_train.shape[1])
-        y_train_boot = y_train_chunked[train_chunk_indices].reshape(-1, y_train.shape[1])
-        
+
+        X_train_boot = X_train_chunked[train_chunk_indices].reshape(
+            -1, X_train.shape[1]
+        )
+        y_train_boot = y_train_chunked[train_chunk_indices].reshape(
+            -1, y_train.shape[1]
+        )
+
         X_val_boot = X_train_chunked[val_chunk_indices].reshape(-1, X_train.shape[1])
         y_val_boot = y_train_chunked[val_chunk_indices].reshape(-1, y_train.shape[1])
 
         boot_scores = np.zeros((len(alphas), y_train.shape[1]))
-        
+
         for ai, alpha in enumerate(alphas):
             ridge = Ridge(alpha=alpha)
             ridge.fit(X_train_boot, y_train_boot)
             y_val_pred = ridge.predict(X_val_boot)
-            
+
             boot_scores[ai, :] = score_fct(y_val_boot, y_val_pred)
-        
+
         all_boot_scores[iboot] = boot_scores
 
     mean_scores = np.mean(all_boot_scores, axis=0)
     best_alpha_indices = np.argmax(mean_scores, axis=0)
     best_alphas = alphas[best_alpha_indices]
-    
+
     unique_alphas = np.unique(best_alphas)
     weights = np.zeros((X_train.shape[1], y_train.shape[1]))
     y_predict = np.zeros((X_test.shape[0], y_test.shape[1]))
-    
+
     for alpha in unique_alphas:
         voxel_mask = best_alphas == alpha
         ridge = Ridge(alpha=alpha)
         ridge.fit(X_train, y_train[:, voxel_mask])
-        weights[:, voxel_mask] = ridge.coef_.T
-        y_predict[:, voxel_mask] = ridge.predict(X_test)
-    
+        weights[:, voxel_mask] = np.atleast_2d(ridge.coef_).T
+        pred = ridge.predict(X_test)
+        if pred.ndim == 1:
+            pred = pred.reshape(-1, 1)
+        y_predict[:, voxel_mask] = pred
+
     scores = score_fct(y_test, y_predict)
 
     return scores, weights, best_alphas
+
 
 def ridge_regression_huth(
     train_stories: list[str],

--- a/tests/test_data_regression.py
+++ b/tests/test_data_regression.py
@@ -1,0 +1,75 @@
+import numpy as np
+import pytest
+
+
+@pytest.fixture
+def regression_test_data():
+    """
+    Create lightweight test data for regression testing.
+
+    Returns:
+    --------
+    dict: Contains X_data_dict and y_data_dict with simulated data
+          - 4 stories total (3 train, 1 test)
+          - Each story has ~100 samples with 5-dimensional features
+          - Each story has 3 response channels (simulating brain regions)
+    """
+    rng = np.random.default_rng(42)
+
+    n_samples = 100
+    n_features = 5
+    n_channels = 3
+    stories = ["story1", "story2", "story3", "story4"]
+
+    X_data_dict = {}
+    y_data_dict = {}
+
+    for story in stories:
+        X_data_dict[story] = rng.standard_normal((n_samples, n_features))
+
+        true_weights = rng.standard_normal((n_features, n_channels)) * 0.5
+        noise = rng.standard_normal((n_samples, n_channels)) * 0.3
+        y_data_dict[story] = np.dot(X_data_dict[story], true_weights) + noise
+
+    return {
+        "X_data_dict": X_data_dict,
+        "y_data_dict": y_data_dict,
+        "stories": stories,
+        "true_weights": true_weights,
+    }
+
+
+@pytest.fixture
+def train_test_split():
+    """
+    Define train/test split mimicking cross-validation setup.
+
+    Returns:
+    --------
+    dict: Contains train_stories and test_stories lists
+    """
+    return {"train_stories": ["story1", "story2", "story3"], "test_stories": ["story4"]}
+
+
+@pytest.fixture
+def small_regression_data():
+    """
+    Even smaller dataset for quick testing.
+
+    Returns:
+    --------
+    dict: Contains X_data_dict and y_data_dict with minimal data
+    """
+    rng = np.random.default_rng(123)
+
+    X_data_dict = {
+        "train": rng.standard_normal((20, 3)),
+        "test": rng.standard_normal((10, 3)),
+    }
+
+    y_data_dict = {
+        "train": rng.standard_normal((20, 2)),
+        "test": rng.standard_normal((10, 2)),
+    }
+
+    return {"X_data_dict": X_data_dict, "y_data_dict": y_data_dict}

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -8,7 +8,15 @@ from test_data_regression import (
     train_test_split,
 )
 
-from encoders.regression import pearsonr, pearsonr_scorer, ridge_regression, z_score, zs
+from encoders.regression import (
+    pearsonr,
+    pearsonr_scorer,
+    ridge_regression,
+    ridge_regression_chunkbootstrap,
+    ridge_regression_huth,
+    z_score,
+    zs,
+)
 
 # ruff: noqa: F811 - pytest fixtures are injected by name
 
@@ -109,6 +117,63 @@ def test_ridge_regression_basic(regression_test_data, train_test_split):
 
     assert scores.shape == (3,)
     assert weights.shape == (3, 5)
+    assert best_alphas.shape == (3,)
+
+
+def test_ridge_regression_huth_basic(small_regression_data):
+    """Test basic functionality of ridge_regression_huth."""
+    X_data_dict = small_regression_data["X_data_dict"]
+    y_data_dict = small_regression_data["y_data_dict"]
+
+    scores, weights, best_alphas = ridge_regression_huth(
+        train_stories=["train"],
+        test_stories=["test"],
+        X_data_dict=X_data_dict,
+        y_data_dict=y_data_dict,
+        score_fct=pearsonr,
+        alphas=np.array([1.0, 10.0]),
+        nboots=2,
+        chunklen=5,
+        nchunks=2,
+        singcutoff=1e-10,
+        single_alpha=False,
+        use_corr=True,
+    )
+
+    assert isinstance(scores, np.ndarray)
+    assert isinstance(weights, np.ndarray)
+    assert isinstance(best_alphas, np.ndarray)
+
+    assert scores.shape == (2,)
+    assert weights.shape == (3, 2)
+    assert best_alphas.shape == (2,)
+
+
+def test_ridge_regression_chunkbootstrap_basic(regression_test_data, train_test_split):
+    """Test basic functionality of ridge_regression_chunkbootstrap."""
+    X_data_dict = regression_test_data["X_data_dict"]
+    y_data_dict = regression_test_data["y_data_dict"]
+    train_stories = train_test_split["train_stories"]
+    test_stories = train_test_split["test_stories"]
+
+    scores, weights, best_alphas = ridge_regression_chunkbootstrap(
+        train_stories=train_stories,
+        test_stories=test_stories,
+        X_data_dict=X_data_dict,
+        y_data_dict=y_data_dict,
+        score_fct=pearsonr,
+        alphas=np.array([1.0, 10.0]),
+        nboots=2,
+        chunklen=10,
+        nchunks=5,
+    )
+
+    assert isinstance(scores, np.ndarray)
+    assert isinstance(weights, np.ndarray)
+    assert isinstance(best_alphas, np.ndarray)
+
+    assert scores.shape == (3,)
+    assert weights.shape == (5, 3)
     assert best_alphas.shape == (3,)
 
 

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,0 +1,309 @@
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+from test_data_regression import (
+    regression_test_data,
+    small_regression_data,
+    train_test_split,
+)
+
+from encoders.regression import pearsonr, pearsonr_scorer, ridge_regression, z_score, zs
+
+# ruff: noqa: F811 - pytest fixtures are injected by name
+
+
+def test_zs_1d():
+    """Test z-score normalization for 1D arrays."""
+    x = np.array([1, 2, 3, 4, 5])
+    z = zs(x)
+
+    assert np.allclose(z.mean(), 0, atol=1e-10)
+    assert np.allclose(z.std(), 1)
+
+
+def test_zs_2d():
+    """Test z-score normalization for 2D arrays."""
+    rng = np.random.default_rng(42)
+    x = rng.standard_normal((10, 3))
+    z = zs(x)
+
+    assert z.shape == x.shape
+    assert np.allclose(z.mean(axis=0), 0, atol=1e-10)
+    assert np.allclose(z.std(axis=0), 1)
+
+
+def test_z_score_with_given_stats():
+    """Test z-score normalization with provided means and stds."""
+    data = np.array([[1, 2], [3, 4], [5, 6]])
+    means = np.array([3, 4])
+    stds = np.array([2, 2])
+
+    normalized = z_score(data, means, stds)
+    expected = (data - means) / stds
+
+    assert np.allclose(normalized, expected)
+
+
+def test_pearsonr_1d():
+    """Test Pearson correlation for 1D arrays."""
+    x1 = np.array([1, 2, 3, 4, 5])
+    x2 = np.array([2, 4, 6, 8, 10])
+
+    corr = pearsonr(x1, x2)
+
+    assert isinstance(corr, (float, np.floating))
+    assert np.allclose(corr, 1.0)
+
+
+def test_pearsonr_2d():
+    """Test Pearson correlation for 2D arrays."""
+    rng = np.random.default_rng(42)
+    x1 = rng.standard_normal((100, 3))
+    x2 = x1 + rng.standard_normal((100, 3)) * 0.1
+
+    corr = pearsonr(x1, x2)
+
+    assert isinstance(corr, np.ndarray)
+    assert corr.shape == (3,)
+    assert np.all(corr > 0.5)
+
+
+def test_pearsonr_scorer():
+    """Test the scoring function for RidgeCV."""
+    from sklearn.linear_model import Ridge
+
+    rng = np.random.default_rng(42)
+    X = rng.standard_normal((50, 4))
+    y = rng.standard_normal((50, 2))
+
+    estimator = Ridge()
+    estimator.fit(X, y)
+
+    score = pearsonr_scorer(estimator, X, y)
+
+    assert isinstance(score, (float, np.ndarray))
+    if isinstance(score, np.ndarray):
+        assert score.shape == (2,)
+
+
+def test_ridge_regression_basic(regression_test_data, train_test_split):
+    """Test basic functionality of ridge_regression."""
+    X_data_dict = regression_test_data["X_data_dict"]
+    y_data_dict = regression_test_data["y_data_dict"]
+    train_stories = train_test_split["train_stories"]
+    test_stories = train_test_split["test_stories"]
+
+    scores, weights, best_alphas = ridge_regression(
+        train_stories=train_stories,
+        test_stories=test_stories,
+        X_data_dict=X_data_dict,
+        y_data_dict=y_data_dict,
+        score_fct=pearsonr,
+        alphas=np.logspace(0, 2, 5),
+    )
+
+    assert isinstance(scores, np.ndarray)
+    assert isinstance(weights, np.ndarray)
+    assert isinstance(best_alphas, np.ndarray)
+
+    assert scores.shape == (3,)
+    assert weights.shape == (3, 5)
+    assert best_alphas.shape == (3,)
+
+
+def test_ridge_regression_shapes(small_regression_data):
+    """Test that ridge_regression produces correct output shapes."""
+    X_data_dict = small_regression_data["X_data_dict"]
+    y_data_dict = small_regression_data["y_data_dict"]
+
+    scores, weights, best_alphas = ridge_regression(
+        train_stories=["train"],
+        test_stories=["test"],
+        X_data_dict=X_data_dict,
+        y_data_dict=y_data_dict,
+        score_fct=pearsonr,
+        alphas=np.array([1.0, 10.0]),
+    )
+
+    assert scores.shape == (2,)
+    assert weights.shape == (2, 3)
+    assert best_alphas.shape == (2,)
+
+
+def test_ridge_regression_default_alphas(small_regression_data):
+    """Test ridge_regression with default alpha values."""
+    X_data_dict = small_regression_data["X_data_dict"]
+    y_data_dict = small_regression_data["y_data_dict"]
+
+    scores, weights, best_alphas = ridge_regression(
+        train_stories=["train"],
+        test_stories=["test"],
+        X_data_dict=X_data_dict,
+        y_data_dict=y_data_dict,
+        score_fct=pearsonr,
+    )
+
+    assert scores.shape == (2,)
+    assert weights.shape == (2, 3)
+    assert best_alphas.shape == (2,)
+
+
+def test_ridge_regression_none_alphas(small_regression_data):
+    """Test ridge_regression with None alphas (should use default)."""
+    X_data_dict = small_regression_data["X_data_dict"]
+    y_data_dict = small_regression_data["y_data_dict"]
+
+    scores, weights, best_alphas = ridge_regression(
+        train_stories=["train"],
+        test_stories=["test"],
+        X_data_dict=X_data_dict,
+        y_data_dict=y_data_dict,
+        score_fct=pearsonr,
+        alphas=None,
+    )
+
+    assert scores.shape == (2,)
+    assert weights.shape == (2, 3)
+    assert best_alphas.shape == (2,)
+
+
+def test_ridge_regression_multiple_train_stories(
+    regression_test_data, train_test_split
+):
+    """Test ridge_regression with multiple training stories."""
+    X_data_dict = regression_test_data["X_data_dict"]
+    y_data_dict = regression_test_data["y_data_dict"]
+    train_stories = train_test_split["train_stories"]
+    test_stories = train_test_split["test_stories"]
+
+    scores, weights, best_alphas = ridge_regression(
+        train_stories=train_stories,
+        test_stories=test_stories,
+        X_data_dict=X_data_dict,
+        y_data_dict=y_data_dict,
+        score_fct=pearsonr,
+        alphas=np.array([1.0, 100.0]),
+    )
+
+    assert len(train_stories) == 3
+    assert len(test_stories) == 1
+    assert scores.shape == (3,)
+
+
+def test_ridge_regression_data_normalization(small_regression_data):
+    """Test that data is properly normalized during ridge regression."""
+    X_data_dict = small_regression_data["X_data_dict"]
+    y_data_dict = small_regression_data["y_data_dict"]
+
+    with patch("encoders.regression.z_score") as mock_z_score:
+        mock_z_score.side_effect = lambda data, means, stds: (data - means) / (
+            stds + 1e-6
+        )
+
+        ridge_regression(
+            train_stories=["train"],
+            test_stories=["test"],
+            X_data_dict=X_data_dict,
+            y_data_dict=y_data_dict,
+            score_fct=pearsonr,
+            alphas=np.array([1.0]),
+        )
+
+        assert mock_z_score.call_count == 2
+
+
+def test_ridge_regression_score_function_called(small_regression_data):
+    """Test that the scoring function is called correctly."""
+    X_data_dict = small_regression_data["X_data_dict"]
+    y_data_dict = small_regression_data["y_data_dict"]
+
+    def mock_score(y_true, y_pred):
+        return np.array([0.5, 0.6])
+
+    scores, weights, best_alphas = ridge_regression(
+        train_stories=["train"],
+        test_stories=["test"],
+        X_data_dict=X_data_dict,
+        y_data_dict=y_data_dict,
+        score_fct=mock_score,
+        alphas=np.array([1.0]),
+    )
+
+    assert np.allclose(scores, [0.5, 0.6])
+
+
+def test_ridge_regression_single_alpha(small_regression_data):
+    """Test ridge regression with a single alpha value."""
+    X_data_dict = small_regression_data["X_data_dict"]
+    y_data_dict = small_regression_data["y_data_dict"]
+
+    scores, weights, best_alphas = ridge_regression(
+        train_stories=["train"],
+        test_stories=["test"],
+        X_data_dict=X_data_dict,
+        y_data_dict=y_data_dict,
+        score_fct=pearsonr,
+        alphas=np.array([1.0]),
+    )
+
+    assert scores.shape == (2,)
+    assert weights.shape == (2, 3)
+    assert best_alphas.shape == (2,)
+    assert np.all(best_alphas == 1.0)
+
+
+def test_ridge_regression_reproducibility(small_regression_data):
+    """Test that ridge regression gives consistent results."""
+    X_data_dict = small_regression_data["X_data_dict"]
+    y_data_dict = small_regression_data["y_data_dict"]
+
+    scores1, weights1, alphas1 = ridge_regression(
+        train_stories=["train"],
+        test_stories=["test"],
+        X_data_dict=X_data_dict,
+        y_data_dict=y_data_dict,
+        score_fct=pearsonr,
+        alphas=np.array([1.0, 10.0]),
+    )
+
+    scores2, weights2, alphas2 = ridge_regression(
+        train_stories=["train"],
+        test_stories=["test"],
+        X_data_dict=X_data_dict,
+        y_data_dict=y_data_dict,
+        score_fct=pearsonr,
+        alphas=np.array([1.0, 10.0]),
+    )
+
+    assert np.allclose(scores1, scores2)
+    assert np.allclose(weights1, weights2)
+    assert np.allclose(alphas1, alphas2)
+
+
+def test_ridge_regression_with_zero_variance_features():
+    """Test ridge regression handles zero-variance features properly."""
+    rng = np.random.default_rng(42)
+
+    X_data_dict = {
+        "train": np.column_stack([rng.standard_normal((20, 2)), np.ones(20)]),
+        "test": np.column_stack([rng.standard_normal((10, 2)), np.ones(10)]),
+    }
+
+    y_data_dict = {
+        "train": rng.standard_normal((20, 2)),
+        "test": rng.standard_normal((10, 2)),
+    }
+
+    scores, weights, best_alphas = ridge_regression(
+        train_stories=["train"],
+        test_stories=["test"],
+        X_data_dict=X_data_dict,
+        y_data_dict=y_data_dict,
+        score_fct=pearsonr,
+        alphas=np.array([1.0]),
+    )
+
+    assert scores.shape == (2,)
+    assert weights.shape == (2, 3)
+    assert best_alphas.shape == (2,)


### PR DESCRIPTION
This PR adds a set of unit tests for the main functions from the `regression.py` module (`tests/test_regression.py`) on a small random dataset (created in `tests/test_data_regression.py`) mimicking the data loaded via `encoders.features.load_data_dict()`. This PR also runs formatting on some of the recently adding functions in regression.py.

Scaffolded with AI assistance, apologies for the large diff. But tests do make sense to my checking and runs fast.